### PR TITLE
build.sh: check correct compiler

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Check for gcc version according to
 # https://unix.stackexchange.com/questions/285924/how-to-compare-a-programs-version-in-a-shell-script
-currentgccver="$(gcc -dumpversion)"
+currentgccver="$($GCC_HOST_COMPILER_PATH -dumpversion)"
 requiredgccver="5.0.0"
 
 OPTFLAG=""


### PR DESCRIPTION
Previously, build.sh checkd the version of `gcc`, picking whichever
version of `gcc` comes first in a user's `PATH`. However,
`tf_exports.sh` also allows setting a specific `gcc` path through the
`GCC_HOST_COMPILER_PATH` variable.

This commit changes `build.sh` to check the version of that compiler,
instead of relying on `gcc` in the user's `PATH`.

For me, for example, this resulted in a build failure, since i had selected `gcc-4.9` in `GCC_HOST_COMPILER_PATH`, while my `gcc` is version 6.3. After this change, I was able to build it successfully.

Best regards,
Christian